### PR TITLE
Add admin layout

### DIFF
--- a/app/assets/stylesheets/admin/custom_admin.scss
+++ b/app/assets/stylesheets/admin/custom_admin.scss
@@ -1,0 +1,34 @@
+#wrapper {
+	.admin-sidebar-wrapper {
+		width: 250px !important;
+	}
+
+	.admin-page-content-wrapper {
+		#page-container {
+			width: calc(100% - 250px) !important;
+			float: right;
+			#container {
+				.page-header {
+					padding: 0 !important;
+				}
+
+				.header {
+					display: flex;
+					margin: 24px 0;
+
+					#search-book-form {
+						flex: 4;
+						margin: 0 !important;
+					}
+
+					#add-book-button {
+						flex: 1;
+						a {
+							float: right;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/app/assets/stylesheets/application_admin.scss
+++ b/app/assets/stylesheets/application_admin.scss
@@ -1,0 +1,20 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
+ * vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
+ * files in this directory. Styles in this file should be added after the last require_* statement.
+ * It is generally better to create a new file per style scope.
+ *
+ *= require_tree .
+ *= require_self
+ *= require_directory ./admin
+ *= require _bootstrap-sprockets
+ *= require _bootstrap
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito&family=Open+Sans&family=Roboto&display=swap');

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,12 @@
+class Admin::AdminController < ApplicationController
+  layout "admin/layouts/application_admin"
+  before_action :is_admin?
+
+  private
+
+  def is_admin?
+    return true if current_user&.admin?
+
+    redirect_to root_path
+  end
+end

--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -1,0 +1,8 @@
+class Admin::BooksController < Admin::AdminController
+  def index
+    all_books = Book.order_by_time_created
+                    .by_title(params[:search_text])
+                    .by_genre(params[:genre_id])
+    @pagy, @books = pagy all_books, items: Settings.book.BOOK_PER_PAGE
+  end
+end

--- a/app/controllers/admin/static_pages_controller.rb
+++ b/app/controllers/admin/static_pages_controller.rb
@@ -1,0 +1,3 @@
+class Admin::StaticPagesController < Admin::AdminController
+  def index; end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,6 +25,8 @@ class SessionsController < ApplicationController
     log_in user
     params[:session][:remember_me] == "1" ? remember(user) : forget(user)
     flash[:success] = t ".login_success"
+    return redirect_to admin_root_path if user.admin?
+
     redirect_to root_url
   end
 end

--- a/app/javascript/packs/application_admin.js
+++ b/app/javascript/packs/application_admin.js
@@ -1,0 +1,11 @@
+import Rails from '@rails/ujs'
+import Turbolinks from 'turbolinks'
+import * as ActiveStorage from '@rails/activestorage'
+import 'channels'
+require('jquery')
+require('bootstrap')
+require('@fortawesome/fontawesome-free/js/all')
+
+Rails.start()
+Turbolinks.start()
+ActiveStorage.start()

--- a/app/views/admin/books/_book.html.erb
+++ b/app/views/admin/books/_book.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <td><%= book.title %></td>
+  <td><%= get_authors_name book %></td>
+  <td><%= get_genres_name book %></td>
+  <td><%= get_total_pages book %></td>
+  <td><%= book.reviews.count %></td>
+  <td><%= get_average_rating book %></td>
+  <td><%= book.lock_reviewing %></td>
+  <td>
+    <%= link_to t("delete"), "#",
+                data: {confirm: t("admin.books.destroy.are_you_sure")} %>
+    <%= link_to t("update"), "#" %>
+  </td>
+</tr>

--- a/app/views/admin/books/index.html.erb
+++ b/app/views/admin/books/index.html.erb
@@ -1,0 +1,37 @@
+<%= provide :page_title, t("admin.manage_book") %>
+<div class="header">
+  <div id="search-book-form">
+    <%= form_tag admin_books_path, method: :get do %>
+      <%= text_field_tag :search_text, params[:search_text],
+                         placeholder: t("books.index.enter_book_title"),
+                         class: "input-text nunito" %>
+      <%= select_tag :genre_id, options_for_select(get_genres_for_filter),
+                     class: "input-select nunito" %>
+      <%= submit_tag t("search"), class: "btn btn-primary my-button" %>
+    <% end %>
+  </div>
+  <div id="add-book-button">
+    <%= link_to t(".add_new_book"), "#",
+                class: "my-button btn btn-primary" %>
+  </div>
+</div>
+<div id="books-table">
+  <table class="table table-hover">
+    <thead>
+    <tr>
+      <th><%= t ".title" %></th>
+      <th><%= t ".author" %></th>
+      <th><%= t ".genre" %></th>
+      <th><%= t ".total_pages" %></th>
+      <th><%= t ".number_of_review" %></th>
+      <th><%= t ".average_rating" %></th>
+      <th><%= t ".is_lock" %></th>
+      <th><%= t ".more_action" %></th>
+    </tr>
+    </thead>
+    <tbody>
+    <%= render partial: "admin/books/book", collection: @books %>
+    </tbody>
+  </table>
+</div>
+<%== pagy_nav @pagy %>

--- a/app/views/admin/layouts/_admin_sidebar.html.erb
+++ b/app/views/admin/layouts/_admin_sidebar.html.erb
@@ -1,0 +1,14 @@
+<div id="sidebar-wrapper" class="admin-sidebar-wrapper">
+  <div class="sidebar-avatar">
+    <%= image_tag get_avatar_url(current_user),
+                  alt: t("avatar"), class: "avatar" %>
+  </div>
+  <ul class="sidebar-nav">
+    <li><%= link_to t("home"), admin_root_path %></li>
+    <li><%= link_to t("admin.manage_user"), "#" %></li>
+    <li><%= link_to t("admin.manage_book"), admin_books_path %></li>
+    <li><%= link_to t("admin.manage_genre"), "#" %></li>
+    <li><%= link_to t("admin.user_interface"), root_path %></li>
+    <li><%= link_to t("log_out"), logout_path, method: :delete %></li>
+  </ul>
+</div>

--- a/app/views/admin/layouts/application_admin.html.erb
+++ b/app/views/admin/layouts/application_admin.html.erb
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= t "app_name" %></title>
+  <%= render "layouts/shim" %>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= stylesheet_link_tag "application_admin", media: "all",
+                          "data-turbolinks-track": "reload" %>
+  <%= javascript_pack_tag "application_admin",
+                          "data-turbolinks-track": "reload" %>
+</head>
+<body>
+<div id="wrapper">
+  <%= render "admin/layouts/admin_sidebar" %>
+  <div id="page-content-wrapper" class="admin-page-content-wrapper">
+    <div id="page-container">
+      <div id="container">
+        <h1 id="name-app-header"><%= t "admin_interface" %></h1>
+        <% flash.each do |message_type, message| %>
+          <div class="alert alert-<%= message_type %>">
+            <%= message %>
+          </div>
+        <% end %>
+        <ul class="page-header">
+          <li><h2 class="page-title"><%= yield :page_title %></h2></li>
+          <%= render "shared/language" %>
+        </ul>
+        <%= yield %>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/app/views/admin/static_pages/index.html.erb
+++ b/app/views/admin/static_pages/index.html.erb
@@ -1,0 +1,1 @@
+<%= provide :page_title, t("home") %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div id="sidebar-wrapper">
   <div class="sidebar-avatar">
-    <% if logged_in? %>
+    <% if logged_in? && current_user.picture %>
       <%= image_tag current_user.picture_url, alt: t("avatar"), class: "avatar" %>
     <% else %>
       <%= image_tag "avatar_example.png", alt: t("avatar"), class: "avatar" %>
@@ -11,6 +11,9 @@
     <li><%= link_to t("book"), books_path %></li>
     <% if logged_in? %>
       <li><%= link_to t("profile"), user_path(current_user) %></li>
+      <% if current_user.admin? %>
+        <li><%= link_to t("admin_interface"), admin_root_path %></li>
+      <% end %>
       <li><%= link_to t("log_out"), logout_path, method: :delete %></li>
     <% else %>
       <li><%= link_to t("sign_in"), login_path %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,8 @@ en:
   following: "Following"
   name: "Name"
   email: "Email"
+  admin_interface: "Admin interface"
+  upload_book_cover: "Upload book's cover"
   static_pages:
     home:
       quotes: "With books you can go places"
@@ -78,3 +80,26 @@ en:
   users_relationships:
     followed_user_not_found: "Not found followed user"
     not_found_relationship: "Not found relationship with this user"
+  admin:
+    manage_user: "Manage user"
+    manage_book: "Manage book"
+    manage_genre: "Manage genre"
+    user_interface: "User interface"
+    books:
+      index:
+        title: "Title"
+        author: "Author"
+        genre: "Genre"
+        total_pages: "Total pages"
+        number_of_review: "Number of reviews"
+        average_rating: "Average rating"
+        is_lock: "Is lock"
+        more_action: "More action"
+        add_new_book: "Add book"
+      create:
+        create_success: "Create new book successfully"
+        create_fail: "Create new book fail"
+      destroy:
+        success: "Delete book successfully"
+        fail: "Delete book fail"
+        are_you_sure: "Are you sure to delete this book?"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -28,6 +28,8 @@ vi:
   following: "Số người bạn đang theo dõi"
   name: "Tên"
   email: "Email"
+  admin_interface: "Giao diện admin"
+  upload_book_cover: "Tải bìa sách"
   static_pages:
     home:
       quotes: "Sách mở mang tầm nhìn của bạn"
@@ -78,3 +80,26 @@ vi:
   users_relationships:
     followed_user_not_found: "Không tìm thấy người mà bạn đang theo dõi"
     not_found_relationship: "Không tìm thấy mối quan hệ với người dùng "
+  admin:
+    manage_user: "Người dùng"
+    manage_book: "Sách"
+    manage_genre: "Thể loại sách"
+    user_interface: "Giao diện user"
+    books:
+      index:
+        title: "Tiêu đề"
+        author: "Tác giả"
+        genre: "Thể loại"
+        total_pages: "Số trang"
+        number_of_review: "Lượng đánh giá"
+        average_rating: "Điểm trung bình"
+        is_lock: "Khóa đánh giá"
+        more_action: "Hành động"
+        add_new_book: "Thêm sách"
+      create:
+        create_success: "Thêm sách thành công."
+        create_fail: "Thêm sách thất bại, mời thử lại."
+      destroy:
+        success: "Xóa sách thành công."
+        fail: "Xóa sách thất bại."
+        are_you_sure: "Bạn chắc chắn muốn xóa cuốn sách này?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,11 @@ Rails.application.routes.draw do
     resources :reviews, except: %i(new show)
     resources :stars, only: :index
     resources :users_relationships, only: %i(create destroy)
+
+    namespace :admin do
+      root "static_pages#index"
+      resources :static_pages, only: :index
+      resources :books, only: :index
+    end
   end
 end


### PR DESCRIPTION
## Related Tickets
- [#52680](https://edu-redmine.sun-asterisk.vn/issues/52680)

## WHAT
- Thêm layout admin riêng biệt.
- Hiển thị bảng book và chức năng search tương tự bên user.

## HOW
- Đưa các controller, route... vào trong namespace admin, sau đó tạo layout cho site admin như thông thường.
- Khi đăng nhập, kiểm tra role của user, nếu user là admin thì chuyển hướng tới site admin.

## Evidence
![Screenshot from 2022-09-16 16-14-41](https://user-images.githubusercontent.com/108849315/190602757-0989aa20-4378-4162-98e8-64652a8c6dfb.png)

